### PR TITLE
Support for regular expressions in URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,11 @@ HTTP server returning configurable responses with support for templates.
 ## Usage
 
 To run http-mockery you'll need to have a config file. Example is available [here](examples/config-example.json).
-Config file needs to include an `endpoints` config if you want to respond with anything else than 404 Not Found.
-Default listening address is "0.0.0.0:8080", but this can be changed with `listen_ip` and `listen_port`.
+Config file needs to include an `endpoints` config if you want to respond with anything else than 404 Not Found. Default listening address is "0.0.0.0:8080", but this can be changed with `listen_ip` and `listen_port`.
 
-Endpoint config needs to have atleast `uri`, `method` and `response_code` to operate normally.
-If you want the endpoint to return anything, you'll also need to provide the name of a `template` file, and 
-`variables` configuration if the template includes anything to replace. Replacable variables are marked with < and >,
-e.g. `<replace_me>`. Matching variable must then be found (see examples). Value can be either provided in the config
-as `value` or as an environment variable where the env var name should be included in the variable config as `env_var`.
-Both `value` and `env_var` can be defined, but env_var always has precedence.
+Endpoint config needs to have atleast `uri`, `method` and `response_code` to operate normally. If you want the endpoint to return any JSON, you'll also need to provide the name of a `template` file, and `variables` configuration if the template includes anything to replace. Replacable variables are marked with < and >, e.g. `<replace_me>`. Matching variable must then be found (see examples). Value can be either provided in the config as `value` or as an environment variable where the env var name should be included in the variable config as `env_var`. Both `value` and `env_var` can be defined, but env_var always has precedence.
+
+Endpoint `type` is defaulted to `normal` but can also be set as `regexp`. It allows for standard regular expressions in the `uri` to match more specific use cases. Endpoints are checked in a given order and first matching endpoint (with correct `uri` and `response_code`) will be used.
 
 All templates must be valid JSON after variable replacement. No other formats are supported at this time (PRs are welcome!)
 

--- a/examples/config-example.json
+++ b/examples/config-example.json
@@ -1,6 +1,7 @@
 {
   "endpoints": [
     {
+      "type": "normal",
       "uri": "/example",
       "method": "GET",
       "template": "response-example.template.json",
@@ -17,12 +18,14 @@
       ]
     },
     {
+      "type": "normal",
       "uri": "/",
       "method": "POST",
       "template": "creation-response-example.template.json",
       "response_code": 201
     },
     {
+      "type": "normal",
       "uri": "/resource-id-2",
       "method": "DELETE",
       "response_code": 204

--- a/pkg/mockery/mockery_test.go
+++ b/pkg/mockery/mockery_test.go
@@ -12,6 +12,7 @@ func testingConfig() mockery.Config {
 	return mockery.Config{
 		Endpoints: []mockery.Endpoint{
 			{
+				Type:         mockery.EndpointTypeNormal,
 				Uri:          "/example",
 				Method:       "GET",
 				ResponseCode: 200,
@@ -24,11 +25,18 @@ func testingConfig() mockery.Config {
 				},
 			},
 			{
+				Type:         mockery.EndpointTypeNormal,
 				Uri:          "/resource",
 				Method:       "POST",
 				ResponseCode: 201,
 				Template:     "../../test/response-resource-creation.json",
 				Variables:    []mockery.Variable{},
+			},
+			{
+				Type:         mockery.EndpointTypeRegex,
+				Uri:          "/resource/[0-9]+",
+				Method:       "DELETE",
+				ResponseCode: 204,
 			},
 		},
 	}
@@ -94,4 +102,8 @@ func TestEndpointMatching(t *testing.T) {
 	endpoint, err := testMocker.MatchEndpoint(&http.Request{Method: http.MethodPost, RequestURI: "/resource"})
 	assert.Equal(t, nil, err, "Endpoint should match")
 	assert.Equal(t, testMocker.Config.Endpoints[1], endpoint, "Should be correctly matched endpoint")
+
+	endpoint, err = testMocker.MatchEndpoint(&http.Request{Method: http.MethodDelete, RequestURI: "/resource/14354"})
+	assert.Equal(t, nil, err, "Endpoint should match")
+	assert.Equal(t, testMocker.Config.Endpoints[2], endpoint, "Should be correctly matched endpoint")
 }


### PR DESCRIPTION
This PR allows for regexp in URIs to more easily match RESTful API endpoints and the likes.