### PR TITLE
feat(proxy): add possibility to proxy unknown urls to upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ oryxBuildBinary
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Test config
+config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN go get ./
 RUN CGO_ENABLED=0 go build -o /app/http-mockery
 RUN chmod +x /app/http-mockery
 
-FROM scratch
+FROM alpine:latest
 
 COPY --from=builder /app/http-mockery /go/bin/http-mockery
+RUN apk update && apk add --no-cache ca-certificate
 ENTRYPOINT ["/go/bin/http-mockery"]

--- a/examples/config-example-proxy-pass.json
+++ b/examples/config-example-proxy-pass.json
@@ -1,0 +1,13 @@
+{
+  "endpoints": [
+    {
+      "type": "normal",
+      "uri": "/test",
+      "method": "GET",
+      "response_code": 200
+    }
+  ],
+  "listen_port": 8000,
+  "listen_ip": "127.0.0.1",
+  "proxy_pass": "https://example.com.localhost/2.0"
+}

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module github.com/ajmyyra/http-mockery
 
 go 1.19
 
-require github.com/valyala/fasttemplate v1.2.2
+require (
+	github.com/stretchr/testify v1.8.1
+	github.com/valyala/fasttemplate v1.2.2
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -51,5 +51,6 @@ func main() {
 		log.Fatal("Config validation failed: ", err.Error())
 	}
 
+	log.Printf("start listening %s", listenAddr)
 	log.Fatal(http.Serve(l, h))
 }


### PR DESCRIPTION
This adds `proxy_pass` config option to pass unknown URL(s) to upstream host that can act as fallback handler for the request.